### PR TITLE
Install v1.2.6 jskeus by using build binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Homebrew tap repository to install [jskeus](https://github.com/euslisp/jskeus) o
 ## Install
 
 ```bash
+brew install xquartz
 brew tap euslisp/jskeus
 brew install jskeus
+```
+
+## Quick Start
+
+```bash
+irteusgl
+(load "irteus/demo/demo.l")
+(full-body-ik)
 ```


### PR DESCRIPTION
I've made some changes to the Homebrew formula for jskeus.

The formula has been updated to distribute a pre-built binary instead of building from source during installation. 
This should make the installation process quicker and more reliable for users.

Additionally, I've updated the README file to mention that XQuartz is now a required dependency when installing jskeus on Apple Silicon machines.

We can quickly check this PR.
```
brew install xquartz
brew tap euslisp/jskeus
brew install jskeus
```
